### PR TITLE
Flujo chat en vivo y Rutas de los chats protegidas

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -102,19 +102,9 @@ function App() {
           }
         />
         <Route path="/gracias" element={<Gratitude />} />
-        <Route
-          path="/DashBoardAdm"
-          element={
-            <AdminProtectedRoute>
-              <DashBoardAdm />
-            </AdminProtectedRoute>
-          }
-        />
+        <Route path="/DashBoardAdm" element={<AdminProtectedRoute><DashBoardAdm /></AdminProtectedRoute>}/>
         <Route path="/unauthRedirect/:props" element={<UnauthRedirect />} />
-        <Route
-          path="/Profile"
-          element={<Profile setLoggedUser={setLoggedUser} />}
-        />
+        <Route path="/Profile" element={<Profile setLoggedUser={setLoggedUser} />}/>
         <Route path="/chat/:emisorId/:receptorId" element={<Mensajeria/>}/>
         <Route path="/:any" element={<NotFound />} />
       </Routes>

--- a/client/src/components/CardDetail/CardDetail.jsx
+++ b/client/src/components/CardDetail/CardDetail.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useEffect } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, redirect, useNavigate, useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 
 // import Footer from "../Footer/Footer";
@@ -14,6 +14,7 @@ import MapView from "../MapView/MapView";
 const CardDetail = () => {
   const dispatch = useDispatch();
   const pet = useSelector((state) => state.pet);
+  const navigate = useNavigate();
 
   const { id } = useParams();
 
@@ -23,23 +24,46 @@ const CardDetail = () => {
 
   const handleSendMail = async () => {
     try {
-      // idUser seria el id del que adopta y lo sacariamos del login que hicieron naza y adri.
       const userLocalStorage = JSON.parse(localStorage.getItem("loggedUser"));
       const userId = userLocalStorage.data.id;
-      await axios.post("http://localhost:3001/mails", {
-        idUser: userId,
-        idGiver: pet.userId,
-        idPet: pet.id,
+      swal("¿Cómo desea contactarse?", {
+        buttons: {
+          email: {
+            text: "Email",
+            value: "email"
+          },
+          chat: {
+            text: "Chat en vivo",
+            value: "chat",
+          },
+        },
+      })
+      .then((value) => {
+        switch (value) {
+          case "email":
+            axios.post("http://localhost:3001/mails", {
+              idUser: userId,
+              idGiver: pet.userId,
+              idPet: pet.id,
+            })
+            .then(() => {
+              swal(
+                "Enviado.",
+                "Se ha informado su interés hacia la mascota.",
+                "success"
+              );
+            })
+            break;
+          case "chat":
+            console.log("entre");
+            navigate(`../chat/${userId}/${pet.userId}`)
+            break;
+        }
       });
+    } catch (error) {
       swal(
-        "Enviado.",
-        "Se ha informado su interés hacia la mascota.",
-        "success"
-      );
-    } catch (err) {
-      swal(
-        "No enviado.",
-        "No se ha podido informado su interés hacia la mascota.",
+        "No es posible contactarse con el dueño de la mascota.",
+        "Debe registrarse para poder hacerlo.",
         "error"
       );
     }

--- a/client/src/components/Mensajeria/Mensajeria.jsx
+++ b/client/src/components/Mensajeria/Mensajeria.jsx
@@ -6,44 +6,54 @@ import axios from "axios";
 const INICIAL_INPUT = "Escriba su mensaje..."
 
 export default function Mensajeria() {
-
   let [messagge, setMessagge] = useState(INICIAL_INPUT);
   let URL = window.location.href.split("/");
   let receptorId = URL.pop();
   let emisorId = URL.pop();
+  let userLocalStorage = JSON.parse(localStorage.getItem("loggedUser"));
+  let userId = userLocalStorage.data?.id;
 
-  const handleEnviar = (e) => {
-    if (e.key === "Enter" || e.type === "click") {
-        axios.post("http://localhost:3001/message", {"message" : messagge, "emisorId": emisorId, "receptorId": receptorId})
-        .then(()=>{setMessagge("")})
-    }
-  }
-  const handleVaciar = (e) => {
-    if (e.target.value === INICIAL_INPUT) {
-        setMessagge("");
-    }
-  }
-  const handleChange = (e) => {
-    setMessagge(e.target.value);
-  }
-
-  return (
-        <div style={{background: "gray"}}>
-        <div className={styles.container}>
-            <div className={styles.top}>
-                <button className={styles.buttonTop}>{"<"}</button>
-                <h3>Chat en vivo</h3>
-                <button className={styles.buttonTop}>{"x"}</button>
-            </div>
-            <RenderizarMensajes/>
-            <div className={styles.inputContainer}>
-                <p><textarea onChange={handleChange} onClick={handleVaciar} onKeyDown={handleEnviar} className={styles.input} value={messagge} name="messagge" rows="5" cols="70">{messagge}</textarea></p>
-                {messagge && messagge !== INICIAL_INPUT ?
-                    <button onClick={handleEnviar}>Enviar</button>
-                : 
-                    null}
-            </div>
-        </div>
-        </div>
+  if (emisorId != userId) {
+    return (
+      <h1>
+        NO PODES VER CHATS DE OTRAS PERSONAS.
+      </h1>
     )
+  }
+  else {
+    const handleEnviar = (e) => {
+      if (e.key === "Enter" || e.type === "click") {
+          axios.post("http://localhost:3001/message", {"message" : messagge, "emisorId": emisorId, "receptorId": receptorId})
+          .then(()=>{setMessagge("")})
+      }
+    }
+    const handleVaciar = (e) => {
+      if (e.target.value === INICIAL_INPUT) {
+          setMessagge("");
+      }
+    }
+    const handleChange = (e) => {
+      setMessagge(e.target.value);
+    }
+
+    return (
+          <div style={{background: "gray"}}>
+          <div className={styles.container}>
+              <div className={styles.top}>
+                  <button className={styles.buttonTop}>{"<"}</button>
+                  <h3>Chat en vivo</h3>
+                  <button className={styles.buttonTop}>{"x"}</button>
+              </div>
+              <RenderizarMensajes/>
+              <div className={styles.inputContainer}>
+                  <p><textarea onChange={handleChange} onClick={handleVaciar} onKeyDown={handleEnviar} className={styles.input} value={messagge} name="messagge" rows="5" cols="70">{messagge}</textarea></p>
+                  {messagge && messagge !== INICIAL_INPUT ?
+                      <button onClick={handleEnviar}>Enviar</button>
+                  : 
+                      null}
+              </div>
+          </div>
+          </div>
+      )
+  }
 }

--- a/client/src/components/Mensajeria/RenderizarMensajes.jsx
+++ b/client/src/components/Mensajeria/RenderizarMensajes.jsx
@@ -2,20 +2,20 @@ import React, { useEffect, useState } from "react";
 import styles from "./mensajeria.module.css";
 import axios from "axios";
 
-const renderizarMensajes = (mensajes, emisorId) => {
+const renderizarMensajes = (mensajes, emisor, receptor) => {
     return mensajes.map((mensaje, i) => {
-        if (mensaje.EmisorId == emisorId) {
+        if (mensaje.EmisorId == emisor.id) {
             return (
                 <div key={i} className={styles.containerUser2}>
                     <p className={styles.messagge}>{mensaje.message}</p>
-                    <img className={styles.profilePic} src="https://mdbcdn.b-cdn.net/img/Photos/new-templates/bootstrap-chat/ava2-bg.webp" alt="nf" />
+                    <img className={styles.profilePic} src={emisor.image} alt="nf" />
                 </div>
             )
         }
         else {
             return (
                 <div key={i} className={styles.containerUser1}>
-                    <img className={styles.profilePic} src="https://mdbcdn.b-cdn.net/img/Photos/new-templates/bootstrap-chat/ava1-bg.webp" alt="nf"/>
+                    <img className={styles.profilePic} src={receptor.image} alt="nf"/>
                     <p className={styles.messagge}>{mensaje.message}</p> 
                 </div>
             )
@@ -26,19 +26,29 @@ const renderizarMensajes = (mensajes, emisorId) => {
 export default function RenderizarMensajes() {
 
   let [messages, setMessages] = useState([]);
+  let [emisor, setEmisor] = useState({});
+  let [receptor, setReceptor] = useState({});
   let URL = window.location.href.split("/");
   let receptorId = URL.pop();
   let emisorId = URL.pop();
 
   useEffect(() => {
+    axios(`http://localhost:3001/users/${emisorId}`)
+    .then(user => setEmisor(user.data));
+    axios(`http://localhost:3001/users/${receptorId}`)
+    .then(user => setReceptor(user.data));
+  }, [])
+
+  useEffect(() => {
     axios(`http://localhost:3001/message?emisorId=${emisorId}&receptorId=${receptorId}`)
     .then((mensajes) => setMessages(mensajes.data));
+
   }, []) // en un futuro se actualizaria cada vez que mande un mensaje alguno de los dos usuers. ahora solo al inicio.
 
 
   return (
         <div className={styles.mensajes}>
-            {renderizarMensajes(messages, emisorId)}
+            {renderizarMensajes(messages, emisor, receptor)}
         </div>
     )
 }


### PR DESCRIPTION
+ En la siguiente colección de fotos podemos ver el flujo definido.

![Captura de pantalla (191)](https://user-images.githubusercontent.com/111701483/218282567-62f46952-8d10-4f11-8db1-9f89bb6c3c0d.png)

![Captura de pantalla (192)](https://user-images.githubusercontent.com/111701483/218282574-1b8cb6c2-ee86-45a2-aedc-a30ec7024c3b.png)

![Captura de pantalla (193)](https://user-images.githubusercontent.com/111701483/218282578-b62cfc53-fc98-4896-aa96-84f811f95f17.png)


![Captura de pantalla (194)](https://user-images.githubusercontent.com/111701483/218282594-344667a7-f37d-46c0-8fa0-eab6501cd127.png)

![Captura de pantalla (195)](https://user-images.githubusercontent.com/111701483/218282611-128e3353-1b88-4bfb-b3c3-8e07133d93b4.png)

+ En esta imágen el funcionamiento de las rutas protegidas (solo deja ver los chats donde el primer id de la ruta (chat/primerId/segId)) coincida con el id del usuario. es decir, solo se pueden ver chats en los que somos los emisores del mensaje.


![Captura de pantalla (196)](https://user-images.githubusercontent.com/111701483/218282630-f05c7dc9-bada-4aa2-aec3-8f9b91256670.png)

![Captura de pantalla (197)](https://user-images.githubusercontent.com/111701483/218282644-de3a61ae-8156-4f43-9f5a-3348d19c7fe3.png)

Falta: incluir socket.io para que se pueda establecer el chat sin refrescar la página

Observaciones: Si se quiere simular un chat deben abrir dos navegadores distintos con dos cuentas distintas luego ir a la ruta 
chat/userNavegador1id/userNavegador2id en el navegador 1 y a la ruta chat/userNavegador2id/userNavegador1id
en el navegador 2. enviar mensajes e ir refrescando para ver resultados.

*** NPM I EN TODOS LADOS ***